### PR TITLE
issue-3881 - Remove ignoreUrl for customer confirmation

### DIFF
--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -34,7 +34,6 @@
             <argument name="ignoredURLs" xsi:type="array">
                 <item name="confirmSubscribeToNewsletter" xsi:type="string">^/newsletter/subscriber/confirm/.*</item>
                 <item name="unsubscribeFromNewslettter" xsi:type="string">^/newsletter/subscriber/unsubscribe/.*</item>
-                <item name="validateCustomerEmail" xsi:type="string">^/customer/account/confirm/.*</item>
             </argument>
         </arguments>
     </virtualType>


### PR DESCRIPTION
**Issue**
* Fixes https://github.com/scandipwa/scandipwa/issues/3881

**Problems**
* Old ignoredUrl was bypassing customer/account/confirm url to magento controller.

**In this PR**
* Remove old ignoredUrl