### PR TITLE
#3780 - Use custom path for newsletter subscription via email

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,5 @@ In order to allow Magento 2 to handle some routes in default manner (only server
  specific routes to be accessed by adding RegExp to `src/app/etc/di.xml::ignoredURLs` arguments list.
  
 So far there are 3 paths whitelisted out of the box:
-- `/newsletter/subscriber/confirm` - subscribe to newsletter
 - `/newsletter/subscriber/unsubscribe` - unsubscribe to newsletter
 - `/customer/account/confirm/` - confirm e-mail (redirect to homepage in any case, modify according to your needs)

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -32,7 +32,6 @@
     <virtualType name="ScandiPWA\Router\Controller\ConfigurableRouter" type="ScandiPWA\Router\Controller\Router">
         <arguments>
             <argument name="ignoredURLs" xsi:type="array">
-                <item name="confirmSubscribeToNewsletter" xsi:type="string">^/newsletter/subscriber/confirm/.*</item>
                 <item name="unsubscribeFromNewslettter" xsi:type="string">^/newsletter/subscriber/unsubscribe/.*</item>
             </argument>
         </arguments>


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3780

**Problem:**
* Nothing happens when confirming newsletter subscription

**In this PR:**
* The success/failed page opens for confirming newsletter subscription via email