### PR TITLE
TEAMS-580 add search route alwayspass

### DIFF
--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -26,6 +26,7 @@
                 <item name="wishlist" xsi:type="string">ScandiPWA\Router\Validator\Wishlist</item>
                 <item name="checkout" xsi:type="string">ScandiPWA\Router\Validator\AlwaysPass</item>
                 <item name="compare" xsi:type="string">ScandiPWA\Router\Validator\AlwaysPass</item>
+                <item name="search" xsi:type="string">ScandiPWA\Router\Validator\AlwaysPass</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
Ticket: https://scandiflow.atlassian.net/browse/TEAMS-580

Description:

404 status code for search pages is one of the recurring SEO-related issues that is reported after SWPA base theme is uploaded and installed. Here is an example of such an issue

Fixed:

Added alwayspass for search pages