### PR TITLE
Product Disable Fix on PDP

### DIFF
--- a/src/Controller/Router.php
+++ b/src/Controller/Router.php
@@ -501,6 +501,7 @@ class Router extends BaseRouter
      */
     protected function setNotFound(ActionInterface $action)
     {
+        $action->setType('NOT_FOUND');
         $action->setCode(404)->setPhrase('Not Found');
     }
 


### PR DESCRIPTION
**Issue(s) at hand:**
- Addresses the problem of the Product Page displaying as blank when the product is disabled. Issue [#5431](https://github.com/scandipwa/scandipwa/issues/5431).

**Problem Statement:**
- The Product Page exhibits a blank display when the associated product is disabled.

**Changes in this Pull Request (PR):**
- The product page now redirects to a 404 error page if the product is disabled. This occurs when users access the page directly via URL or through external sources like Facebook.